### PR TITLE
新增启用自动更新证书后方便获取平台证书对应的证书序列号函数

### DIFF
--- a/src/main/java/com/wechat/pay/contrib/apache/httpclient/auth/Verifier.java
+++ b/src/main/java/com/wechat/pay/contrib/apache/httpclient/auth/Verifier.java
@@ -7,4 +7,11 @@ public interface Verifier {
   boolean verify(String serialNumber, byte[] message, String signature);
 
   X509Certificate getValidCertificate();
+
+  /**
+   * 获取平台证书对应的SerialNo <p>
+   * 仅适用于开启了自动更新证书可以获取
+   * @return CertificateSerialNo
+   */
+  String getValidCertificateSerialNo();
 }

--- a/src/test/java/com/wechat/pay/contrib/apache/httpclient/AutoUpdateVerifierTest.java
+++ b/src/test/java/com/wechat/pay/contrib/apache/httpclient/AutoUpdateVerifierTest.java
@@ -80,6 +80,7 @@ public class AutoUpdateVerifierTest {
     } finally {
       response1.close();
     }
+    System.out.println("获取自动管理的平台证书序列号: " + verifier.getValidCertificateSerialNo());
   }
 
   @Test


### PR DESCRIPTION
- 需求

    当前如果使用自动更新证书不能很方便的获取该证书对应的序列号，特别是涉及到敏感字段加密后需要上送Wechatpay-Serial(http头)，但是当前好像不是很方便获取该参数，需要再次调用获取证书的接口来得到该参数

- 功能

    希望如果平台证书已经开启了自动更新，那么平台证书的相关功能应该能由该功能维护，所以新增若开启平台证书后，可以方便的获取该参数，自动更新证书后该值同步维护（不影响自加载证书的情况）

- 实现

    在开启自动获取证书后，解密证书时保存了平台证书序列号，并在Verifier接口中新增getValidCertificateSerialNo(仅对开启自动更新证书有效)。

当前提交的代码已完成测试，请做codereview或提供实现该功能，觉得该功能有必要。