### PR TITLE
修正 AutoUpdateCertificatesVerifier 问题

### DIFF
--- a/src/main/java/com/wechat/pay/contrib/apache/httpclient/auth/CertificatesVerifier.java
+++ b/src/main/java/com/wechat/pay/contrib/apache/httpclient/auth/CertificatesVerifier.java
@@ -68,6 +68,16 @@ public class CertificatesVerifier implements Verifier {
                 exist = true;
             }
         }
-        return !exist;
+        return exist;
+    }
+
+    public X509Certificate getLatestCertificate() {
+        X509Certificate latestCert = null;
+        for (X509Certificate x509Cert : certificates.values()) {
+            if (latestCert == null || x509Cert.getNotBefore().after(latestCert.getNotBefore())) {
+                latestCert = x509Cert;
+            }
+        }
+        return latestCert;
     }
 }

--- a/src/main/java/com/wechat/pay/contrib/apache/httpclient/auth/CertificatesVerifier.java
+++ b/src/main/java/com/wechat/pay/contrib/apache/httpclient/auth/CertificatesVerifier.java
@@ -61,4 +61,13 @@ public class CertificatesVerifier implements Verifier {
         throw new NoSuchElementException("没有有效的微信支付平台证书");
     }
 
+    public boolean existCertificate(String serialNumber) {
+        boolean exist = false;
+        for (X509Certificate x509Cert : certificates.values()) {
+            if (x509Cert.getSerialNumber().toString().equals(serialNumber)) {
+                exist = true;
+            }
+        }
+        return !exist;
+    }
 }

--- a/src/main/java/com/wechat/pay/contrib/apache/httpclient/auth/Verifier.java
+++ b/src/main/java/com/wechat/pay/contrib/apache/httpclient/auth/Verifier.java
@@ -11,4 +11,6 @@ public interface Verifier {
 
     X509Certificate getValidCertificate();
 
+    X509Certificate getLatestCertificate();
+
 }

--- a/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
+++ b/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
@@ -61,7 +61,7 @@ public class RsaCryptoTest {
     @Test
     public void encryptTest() throws Exception {
         String text = "helloworld";
-        String ciphertext = RsaCryptoUtil.encryptOAEP(text, verifier.getValidCertificate());
+        String ciphertext = RsaCryptoUtil.encryptOAEP(text, verifier.getLatestCertificate());
 
         System.out.println("ciphertext: " + ciphertext);
     }


### PR DESCRIPTION
1. 修正下载新证书用旧证书验签失败问题
2. 代码格式化、加密信息时使用最新证书