### PR TITLE
新增加解密方法传入transformation

### DIFF
--- a/src/main/java/com/wechat/pay/contrib/apache/httpclient/util/PemUtil.java
+++ b/src/main/java/com/wechat/pay/contrib/apache/httpclient/util/PemUtil.java
@@ -1,6 +1,5 @@
 package com.wechat.pay.contrib.apache.httpclient.util;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -68,8 +67,4 @@ public class PemUtil {
         }
     }
 
-    public static X509Certificate loadCertificate(String certificate){
-        InputStream certStream = new ByteArrayInputStream(certificate.getBytes());
-        return loadCertificate(certStream);
-    }
 }

--- a/src/main/java/com/wechat/pay/contrib/apache/httpclient/util/PemUtil.java
+++ b/src/main/java/com/wechat/pay/contrib/apache/httpclient/util/PemUtil.java
@@ -1,5 +1,6 @@
 package com.wechat.pay.contrib.apache.httpclient.util;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,5 +66,10 @@ public class PemUtil {
         } catch (CertificateException e) {
             throw new RuntimeException("无效的证书", e);
         }
+    }
+
+    public static X509Certificate loadCertificate(String certificate){
+        InputStream certStream = new ByteArrayInputStream(certificate.getBytes());
+        return loadCertificate(certStream);
     }
 }

--- a/src/main/java/com/wechat/pay/contrib/apache/httpclient/util/RsaCryptoUtil.java
+++ b/src/main/java/com/wechat/pay/contrib/apache/httpclient/util/RsaCryptoUtil.java
@@ -19,8 +19,12 @@ public class RsaCryptoUtil {
     private static final String TRANSFORMATION = "RSA/ECB/OAEPWithSHA-1AndMGF1Padding";
 
     public static String encryptOAEP(String message, X509Certificate certificate) throws IllegalBlockSizeException {
+        return encrypt(message, certificate, TRANSFORMATION);
+    }
+
+    public static String encrypt(String message, X509Certificate certificate, String transformation) throws IllegalBlockSizeException {
         try {
-            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            Cipher cipher = Cipher.getInstance(transformation);
             cipher.init(Cipher.ENCRYPT_MODE, certificate.getPublicKey());
             byte[] data = message.getBytes(StandardCharsets.UTF_8);
             byte[] ciphertext = cipher.doFinal(data);
@@ -36,8 +40,12 @@ public class RsaCryptoUtil {
     }
 
     public static String decryptOAEP(String ciphertext, PrivateKey privateKey) throws BadPaddingException {
+        return decrypt(ciphertext, privateKey, TRANSFORMATION);
+    }
+
+    public static String decrypt(String ciphertext, PrivateKey privateKey, String transformation) throws BadPaddingException {
         try {
-            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            Cipher cipher = Cipher.getInstance(transformation);
             cipher.init(Cipher.DECRYPT_MODE, privateKey);
             byte[] data = Base64.getDecoder().decode(ciphertext);
             return new String(cipher.doFinal(data), StandardCharsets.UTF_8);

--- a/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
+++ b/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
@@ -123,7 +123,7 @@ public class RsaCryptoTest {
     }
 
     @Test
-    public void encryptWithTransformationTest() throws IllegalBlockSizeException {
+    public void encryptWithPkcs1TransformationTest() throws IllegalBlockSizeException {
         String text = "helloworld";
         String transformation = "RSA/ECB/PKCS1Padding";
         String encryptedText = RsaCryptoUtil.encrypt(text, PemUtil.loadCertificate(new ByteArrayInputStream(certForEncrypt.getBytes())), transformation);
@@ -131,12 +131,30 @@ public class RsaCryptoTest {
     }
 
     @Test
-    public void decryptWithTransformationTest() throws BadPaddingException {
+    public void decryptWithPkcs1TransformationTest() throws BadPaddingException {
         String encryptedText = "lmkkdBz5CH4Zk6KIEzbyenf+WtKe8nuU9j+t8HonOm4v1OfLRiYhvdcequOSuaz5vjdpX434XjV9Q5LGC8aOC" +
                 "DZs/8LoyR3m/6JpYa0nkGOh6Le2JvSPNXlSq9HUEoElBJD5KsxbsRoif0kuioBGSKvKB0xwIvVtn+S0H2GYya7TC1L/ddhGhI/yx" +
                 "ZgS/TI/Ppej3OzNmu0xA5RjpDR4rGAUrLvV7y/aM4mCN6WOaO6YsAnlGoSbK+P1sepeb0sCaJMClqbLE0Eoz2ve9FQ30w1Vgi5F0" +
                 "2rpDwcZO8EXAkub0L12BN4QWBNK8FaKlS4UZPAGAwutLK6Gylig54Quig==";
         String transformation = "RSA/ECB/PKCS1Padding";
+        assertEquals("helloworld", RsaCryptoUtil.decrypt(encryptedText, PemUtil.loadPrivateKey(privateKeyForDecrypt), transformation));
+    }
+
+    @Test
+    public void encryptWithOaepTransformationTest() throws IllegalBlockSizeException {
+        String text = "helloworld";
+        String transformation = "RSA/ECB/OAEPWithSHA-1AndMGF1Padding";
+        String encryptedText = RsaCryptoUtil.encrypt(text, PemUtil.loadCertificate(new ByteArrayInputStream(certForEncrypt.getBytes())), transformation);
+        System.out.println("encrypted text: " + encryptedText);
+    }
+
+    @Test
+    public void decryptWithOaepTransformationTest() throws BadPaddingException {
+        String encryptedText = "FJ8/0ubyxnMZ0GN2YEUgJgDVPCwMrsTKuLFxycI3jvOAcVTDEEermn2F7+cUtmCYvD2TkHUMHvWeJB6/nSPBD" +
+                "eGuxA4bCr584h2w9bRvVrwtQlnv1HpF2WRdGAuPcgrQcZvMpiH2ysxgPrGPMs9WOr8etxf1FifI0DkMb6w7wl2BDPPK+RfRdZq7T" +
+                "9KBtH2IllVTLUbRSqDGIctgIxB7RMqd3s/eK0p2Qjui8AVgP4j5Spq6JjITgKn0VDOO4JwzU8Zl++BwveoJMkTN150XF5ot+ruZv" +
+                "lNgjP1Hez0/rFxY7gQvxrSDwgL5A9up6JRI741psfs/3HrzBJOBdvO73A==";
+        String transformation = "RSA/ECB/OAEPWithSHA-1AndMGF1Padding";
         assertEquals("helloworld", RsaCryptoUtil.decrypt(encryptedText, PemUtil.loadPrivateKey(privateKeyForDecrypt), transformation));
     }
 

--- a/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
+++ b/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
@@ -38,8 +38,10 @@ public class RsaCryptoTest {
     private static final String mchSerialNo = ""; // 商户证书序列号
     private static final String apiV3Key = ""; // API V3密钥
     private static final String privateKey = "";
-    private static final String merchantCert = "";
     private static final String wechatPaySerial = ""; // 平台证书序列号
+
+    private static final String certForEncrypt = ""; // 用于测试加密功能的证书
+    private static final String privateKeyForDecrypt = ""; // 用于测试解密功能的私钥
 
     private CloseableHttpClient httpClient;
     private CertificatesManager certificatesManager;
@@ -78,9 +80,9 @@ public class RsaCryptoTest {
     public void cryptWithTransformationTest() throws IllegalBlockSizeException, BadPaddingException {
         String email = "lion@tencent.com";
         String transformation = "RSA/ECB/PKCS1Padding";
-        String encryptedEmail = RsaCryptoUtil.encrypt(email, PemUtil.loadCertificate(merchantCert), transformation);
+        String encryptedEmail = RsaCryptoUtil.encrypt(email, PemUtil.loadCertificate(certForEncrypt), transformation);
         System.out.println("encryptedEmail: " + encryptedEmail);
-        assertEquals(email, RsaCryptoUtil.decrypt(encryptedEmail, PemUtil.loadPrivateKey(privateKey), transformation));
+        assertEquals(email, RsaCryptoUtil.decrypt(encryptedEmail, PemUtil.loadPrivateKey(privateKeyForDecrypt), transformation));
     }
 
     @Test

--- a/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
+++ b/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
@@ -42,8 +42,52 @@ public class RsaCryptoTest {
     private static final String privateKey = ""; // 商户API V3私钥
     private static final String wechatPaySerial = ""; // 平台证书序列号
 
-    private static final String certForEncrypt = ""; // 用于测试加密功能的证书
-    private static final String privateKeyForDecrypt = ""; // 用于测试解密功能的私钥
+    private static final String certForEncrypt = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIC4jCCAcoCCQCtzUA6NgI3njANBgkqhkiG9w0BAQsFADAzMQswCQYDVQQGEwJD\n" +
+            "TjERMA8GA1UECAwIc2hhbmdoYWkxETAPBgNVBAcMCHNoYW5naGFpMB4XDTIyMDUw\n" +
+            "OTIwMjE1NloXDTIzMDUwOTIwMjE1NlowMzELMAkGA1UEBhMCQ04xETAPBgNVBAgM\n" +
+            "CHNoYW5naGFpMREwDwYDVQQHDAhzaGFuZ2hhaTCCASIwDQYJKoZIhvcNAQEBBQAD\n" +
+            "ggEPADCCAQoCggEBALMGZq4BnKaX/VXeg9rLkpE7LqQ5uxgIfKMKSvLzCHA3ZfOR\n" +
+            "p9fl8DtD0/svTUJ0JNv/pFRjfNEmlzqSmAW922yBc4uGkDdqrgHmt4/fqsOXcdLt\n" +
+            "foL5txTdgYutq/127HOhxwixAlJA0PHk6QMuLmG4GN+dwQHWAtQROufgupXoPe6y\n" +
+            "B+w4y3GaCLXIoqgHJQDePFy4sYkNAeSlHFvomPz4RAivPemEiTh2AmJ+RTZa3qT7\n" +
+            "8ZzJNqIM0UKHgcPSsMGTzchC7sV9WIDbQZseflz2ZDJIepJeGq/4TSIXBcyd1yUY\n" +
+            "GWfQRb/l640C3Izj3nililXWFLCWW5dKBnUGqdMCAwEAATANBgkqhkiG9w0BAQsF\n" +
+            "AAOCAQEAo4LkShFg+btEjQUxuShD7SQeNh2DDvdCtEQo5IUY7wtgm95fDGgR1QTA\n" +
+            "9IElN0EpiyvHnPlsjisl8heCL/OnTvrvxJyOp64AiPO6l9j7/nbf9cMHXPOaZODa\n" +
+            "hS4rdokqUAswRA7wkiK6+hOPw/90+P7EPw6xCNRYTfl2ii5jirisrkc6iOW2nbUd\n" +
+            "MjFd3gRGBM/ks3oltGbQbTOwntrAb7wy5EYakdZoKix6CQlqZIdbDXJBEgdXPftt\n" +
+            "80ReqYWTWYyffHCuALMzmFw0fd6gFb/md2oIb13tcKCwiAe1mQmnudRsDH5b5Zps\n" +
+            "iSuewmex8WO7a4/lc2WWKpSb/8JwNQ==\n" +
+            "-----END CERTIFICATE-----"; // 用于测试加密功能的证书
+    private static final String privateKeyForDecrypt = "-----BEGIN PRIVATE KEY-----\n" +
+            "MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQCzBmauAZyml/1V\n" +
+            "3oPay5KROy6kObsYCHyjCkry8whwN2XzkafX5fA7Q9P7L01CdCTb/6RUY3zRJpc6\n" +
+            "kpgFvdtsgXOLhpA3aq4B5reP36rDl3HS7X6C+bcU3YGLrav9duxzoccIsQJSQNDx\n" +
+            "5OkDLi5huBjfncEB1gLUETrn4LqV6D3usgfsOMtxmgi1yKKoByUA3jxcuLGJDQHk\n" +
+            "pRxb6Jj8+EQIrz3phIk4dgJifkU2Wt6k+/GcyTaiDNFCh4HD0rDBk83IQu7FfViA\n" +
+            "20GbHn5c9mQySHqSXhqv+E0iFwXMndclGBln0EW/5euNAtyM4954pYpV1hSwlluX\n" +
+            "SgZ1BqnTAgMBAAECggEAUjhnYhVFb9GwPQbEAfGq796BblVBUylarLqmb2wk/PzE\n" +
+            "axgDQQnOyjk9m0g/MH0NDKkdPNCwW5JgtDrtbP2kT/IoMfVsOLdbEW538bDkyY29\n" +
+            "bgU7LEYpyoBs5cyuh+tdb0HmmlxJV6ODEwVx6s8D6EdXzSOzp/c1N1Zuel5g80V/\n" +
+            "oE5pTb6XBObrCq4ZmMT5y59pSroZDV+RlYZqYtXeCdni+9jzVb+7AM50wqp3D17M\n" +
+            "P9OZnYVyiKS9GEM68klXt3dCnp5P80WVLLupin3DODGdkU0kDFWZE+Hw8Xype5iP\n" +
+            "jgJMZwieOsniveAsIjwtRjh0yZ6xJe47G1JOGppK8QKBgQDuM5eyIJhhwkxbQ1ov\n" +
+            "PbRQbeHrdWUuWuruggg2BMXI3RQH5yELyysOY7rrxSob0L90ww7QLtvaw4GNAFsV\n" +
+            "/OpXs1bkn3QD3lCh4jskbe816iHnYpLKcdkewcIove3wVAaT5/VYeyW9R1mXZLFr\n" +
+            "sXAYef1Fys1yg6eM8GuiFGu7yQKBgQDAZtue4T1JNR4IEMXU4wRUmU2itu+7A2W6\n" +
+            "GskyKaXNvKt0g8ZawDIYEl+B35mRJ29O+8rGKIpqqMEfy+En9/aphouMu9S0cFfS\n" +
+            "n/H1M1B9cfscqyXnS/Ed1kCC9SlfkRXuJ+HhZQ7Zt95vHwf2ugYeg6GDtghC4JHA\n" +
+            "NIdntlOOuwKBgQCi8IvN/1n9VUmiDBp+wji7485soGtMIEkgSbaQLQeWdRQkq8gB\n" +
+            "J0MWnsXYTZCWYl704hEZ+1PM+3t9Fkc4bT9oKndAAIr9sm95rSVDsCe3u6bhfp5m\n" +
+            "+SXKUkQcVn+SrAer2ToNAoA4T7xLQUfUIRZKx/embCnJMaHFWRhnUIy5cQKBgQCG\n" +
+            "tHz3E8OQybuo8fVQQ1D42gxc66+UQ6CpV6+di0Mmc/2mqcvqJb3s1JBBoYcm9XEc\n" +
+            "33Tsn92pJ1VvKZMOJLFxp110vt0BJ9aVBJ6mibLE4VRqkfkLo0PBHAw2o+a/nhi4\n" +
+            "kPu4jsSC8hStwBAXUc6O9qHSUVQfXpMs+poCpsiBmQKBgQDO+B/xX6V6GQIrPgiF\n" +
+            "nKpSi566ouXcNxiMIb8w7nu4r/0mJ91roVD0N1TyCOVKTrY/R/4KsQV4pp2bQfV7\n" +
+            "3tYnrSVgBhPHfWkWQG+7sUXWRR5/c8jszKM+no/bsxmqsAJdK2ih/crHD7XrGgXL\n" +
+            "XWU1WCYDnWGKm3byXlLY1tFO/Q==\n" +
+            "-----END PRIVATE KEY-----"; // 用于测试解密功能的私钥
 
     private CloseableHttpClient httpClient;
     private CertificatesManager certificatesManager;
@@ -88,7 +132,10 @@ public class RsaCryptoTest {
 
     @Test
     public void decryptWithTransformationTest() throws BadPaddingException {
-        String encryptedText = "lx+L4CEgNiz62Exe4NY5/EiGl1wSbSIU8LqOx0/xrB0js5jN/nYMqzDgig=="; // 需替换为正确加密后的字符串
+        String encryptedText = "lmkkdBz5CH4Zk6KIEzbyenf+WtKe8nuU9j+t8HonOm4v1OfLRiYhvdcequOSuaz5vjdpX434XjV9Q5LGC8aOC" +
+                "DZs/8LoyR3m/6JpYa0nkGOh6Le2JvSPNXlSq9HUEoElBJD5KsxbsRoif0kuioBGSKvKB0xwIvVtn+S0H2GYya7TC1L/ddhGhI/yx" +
+                "ZgS/TI/Ppej3OzNmu0xA5RjpDR4rGAUrLvV7y/aM4mCN6WOaO6YsAnlGoSbK+P1sepeb0sCaJMClqbLE0Eoz2ve9FQ30w1Vgi5F0" +
+                "2rpDwcZO8EXAkub0L12BN4QWBNK8FaKlS4UZPAGAwutLK6Gylig54Quig==";
         String transformation = "RSA/ECB/PKCS1Padding";
         assertEquals("helloworld", RsaCryptoUtil.decrypt(encryptedText, PemUtil.loadPrivateKey(privateKeyForDecrypt), transformation));
     }

--- a/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
+++ b/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
@@ -5,6 +5,7 @@ import static org.apache.http.HttpHeaders.ACCEPT;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.wechat.pay.contrib.apache.httpclient.auth.PrivateKeySigner;
@@ -27,13 +28,17 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.management.PersistentMBean;
+
 public class RsaCryptoTest {
 
     private static final String mchId = ""; // 商户号
     private static final String mchSerialNo = ""; // 商户证书序列号
     private static final String apiV3Key = ""; // API V3密钥
-    private static final String privateKey = "-----BEGIN PRIVATE KEY-----\n"
-            + "-----END PRIVATE KEY-----\n"; // 商户API V3私钥
+    private static final String privateKey = "";
+    private static final String merchantCert = "";
     private static final String wechatPaySerial = ""; // 平台证书序列号
 
     private CloseableHttpClient httpClient;
@@ -67,6 +72,15 @@ public class RsaCryptoTest {
         String ciphertext = RsaCryptoUtil
                 .encryptOAEP(text, verifier.getValidCertificate());
         System.out.println("ciphertext: " + ciphertext);
+    }
+
+    @Test
+    public void cryptWithTransformationTest() throws IllegalBlockSizeException, BadPaddingException {
+        String email = "lion@tencent.com";
+        String transformation = "RSA/ECB/PKCS1Padding";
+        String encryptedEmail = RsaCryptoUtil.encrypt(email, PemUtil.loadCertificate(merchantCert), transformation);
+        System.out.println("encryptedEmail: " + encryptedEmail);
+        assertEquals(email, RsaCryptoUtil.decrypt(encryptedEmail, PemUtil.loadPrivateKey(privateKey), transformation));
     }
 
     @Test

--- a/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
+++ b/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
@@ -5,6 +5,7 @@ import static org.apache.http.HttpHeaders.ACCEPT;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.wechat.pay.contrib.apache.httpclient.auth.PrivateKeySigner;
@@ -87,9 +88,9 @@ public class RsaCryptoTest {
 
     @Test
     public void decryptWithTransformationTest() throws BadPaddingException {
-        String encryptedText = "L8h0PTZFxq1xelmKLwt7KukA2ghtAEImCD19sE7kAjE9kEb7cpWrK73SsA=="; // 需替换为正确加密后的字符串。
+        String encryptedText = "lx+L4CEgNiz62Exe4NY5/EiGl1wSbSIU8LqOx0/xrB0js5jN/nYMqzDgig=="; // 需替换为正确加密后的字符串
         String transformation = "RSA/ECB/PKCS1Padding";
-        System.out.println("decrypted text: " + RsaCryptoUtil.decrypt(encryptedText, PemUtil.loadPrivateKey(privateKeyForDecrypt), transformation));
+        assertEquals("helloworld", RsaCryptoUtil.decrypt(encryptedText, PemUtil.loadPrivateKey(privateKeyForDecrypt), transformation));
     }
 
     @Test

--- a/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
+++ b/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
@@ -20,6 +20,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
+import java.util.Base64;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -31,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.management.PersistentMBean;
 
@@ -123,11 +126,15 @@ public class RsaCryptoTest {
     }
 
     @Test
-    public void encryptWithPkcs1TransformationTest() throws IllegalBlockSizeException {
+    public void encryptWithPkcs1TransformationTest() throws Exception {
         String text = "helloworld";
         String transformation = "RSA/ECB/PKCS1Padding";
         String encryptedText = RsaCryptoUtil.encrypt(text, PemUtil.loadCertificate(new ByteArrayInputStream(certForEncrypt.getBytes())), transformation);
-        System.out.println("encrypted text: " + encryptedText);
+        //utilize the standard lib to verify the correctness of the encrypted result.
+        Cipher cipher = Cipher.getInstance(transformation);
+        cipher.init(Cipher.DECRYPT_MODE, PemUtil.loadPrivateKey(privateKeyForDecrypt));
+        String secretText = new String((cipher.doFinal(Base64.getDecoder().decode(encryptedText))));
+        assert(text.equals(secretText));
     }
 
     @Test
@@ -141,11 +148,15 @@ public class RsaCryptoTest {
     }
 
     @Test
-    public void encryptWithOaepTransformationTest() throws IllegalBlockSizeException {
+    public void encryptWithOaepTransformationTest() throws Exception {
         String text = "helloworld";
         String transformation = "RSA/ECB/OAEPWithSHA-1AndMGF1Padding";
         String encryptedText = RsaCryptoUtil.encrypt(text, PemUtil.loadCertificate(new ByteArrayInputStream(certForEncrypt.getBytes())), transformation);
-        System.out.println("encrypted text: " + encryptedText);
+        //utilize the standard lib to verify the correctness of the encrypted result.
+        Cipher cipher = Cipher.getInstance(transformation);
+        cipher.init(Cipher.DECRYPT_MODE, PemUtil.loadPrivateKey(privateKeyForDecrypt));
+        String secretText = new String((cipher.doFinal(Base64.getDecoder().decode(encryptedText))));
+        assert(text.equals(secretText));
     }
 
     @Test

--- a/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
+++ b/src/test/java/com/wechat/pay/contrib/apache/httpclient/RsaCryptoTest.java
@@ -5,7 +5,6 @@ import static org.apache.http.HttpHeaders.ACCEPT;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.wechat.pay.contrib.apache.httpclient.auth.PrivateKeySigner;
@@ -15,6 +14,8 @@ import com.wechat.pay.contrib.apache.httpclient.auth.WechatPay2Validator;
 import com.wechat.pay.contrib.apache.httpclient.cert.CertificatesManager;
 import com.wechat.pay.contrib.apache.httpclient.util.PemUtil;
 import com.wechat.pay.contrib.apache.httpclient.util.RsaCryptoUtil;
+
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
@@ -37,7 +38,7 @@ public class RsaCryptoTest {
     private static final String mchId = ""; // 商户号
     private static final String mchSerialNo = ""; // 商户证书序列号
     private static final String apiV3Key = ""; // API V3密钥
-    private static final String privateKey = "";
+    private static final String privateKey = ""; // 商户API V3私钥
     private static final String wechatPaySerial = ""; // 平台证书序列号
 
     private static final String certForEncrypt = ""; // 用于测试加密功能的证书
@@ -77,12 +78,18 @@ public class RsaCryptoTest {
     }
 
     @Test
-    public void cryptWithTransformationTest() throws IllegalBlockSizeException, BadPaddingException {
-        String email = "lion@tencent.com";
+    public void encryptWithTransformationTest() throws IllegalBlockSizeException {
+        String text = "helloworld";
         String transformation = "RSA/ECB/PKCS1Padding";
-        String encryptedEmail = RsaCryptoUtil.encrypt(email, PemUtil.loadCertificate(certForEncrypt), transformation);
-        System.out.println("encryptedEmail: " + encryptedEmail);
-        assertEquals(email, RsaCryptoUtil.decrypt(encryptedEmail, PemUtil.loadPrivateKey(privateKeyForDecrypt), transformation));
+        String encryptedText = RsaCryptoUtil.encrypt(text, PemUtil.loadCertificate(new ByteArrayInputStream(certForEncrypt.getBytes())), transformation);
+        System.out.println("encrypted text: " + encryptedText);
+    }
+
+    @Test
+    public void decryptWithTransformationTest() throws BadPaddingException {
+        String encryptedText = "L8h0PTZFxq1xelmKLwt7KukA2ghtAEImCD19sE7kAjE9kEb7cpWrK73SsA=="; // 需替换为正确加密后的字符串。
+        String transformation = "RSA/ECB/PKCS1Padding";
+        System.out.println("decrypted text: " + RsaCryptoUtil.decrypt(encryptedText, PemUtil.loadPrivateKey(privateKeyForDecrypt), transformation));
     }
 
     @Test


### PR DESCRIPTION
新增encrypt(String message, X509Certificate certificate, String transformation) 和 decrypt(String ciphertext, PrivateKey privateKey, String transformation)允许用户在调用加解密方法时传入特定的transformation, 使现有Java SDK可以兼容境外部分接口加解密使用的RSA/ECB/PKCS1Padding Transformation